### PR TITLE
add l1 permission to squadUp

### DIFF
--- a/src/app/commands/squad/Squad.ts
+++ b/src/app/commands/squad/Squad.ts
@@ -37,6 +37,11 @@ export default class Squad extends SlashCommand {
 				[discordServerIds.banklessDAO]: [
 					{
 						type: ApplicationCommandPermissionType.ROLE,
+						id: roleIds.level1,
+						permission: true,
+					},
+					{
+						type: ApplicationCommandPermissionType.ROLE,
 						id: roleIds.level2,
 						permission: true,
 					},
@@ -52,6 +57,11 @@ export default class Squad extends SlashCommand {
 					},
 				],
 				[discordServerIds.discordBotGarage]: [
+					{
+						type: ApplicationCommandPermissionType.ROLE,
+						id: roleIds.level1,
+						permission: true,
+					},
 					{
 						type: ApplicationCommandPermissionType.ROLE,
 						id: roleIds.level2,
@@ -96,7 +106,7 @@ export default class Squad extends SlashCommand {
 	}
 
 	handleCommandError(ctx: CommandContext, command: Promise<any>): void {
-    
+
 		command.catch(async e => {
 			if (!(e instanceof ValidationError)) {
 				await ServiceUtils.sendOutErrorMessage(ctx);


### PR DESCRIPTION
It was requested to make the command more widely available. This PR will add bDAO L1 users to use the squad up command.